### PR TITLE
Handle bad input files during count merging

### DIFF
--- a/crcClean.py
+++ b/crcClean.py
@@ -6,23 +6,18 @@ Merge TCGA HTSeq-Counts files -> log2‑CPM matrix
 from pathlib import Path
 import pandas as pd
 import numpy as np
+import logging
+
+logging.basicConfig(level=logging.INFO)
 
 #EDIT THIS ONLY if your folder lives elsewhere
 ROOT = Path("/Users/emmaleute/Downloads/GDC_download")
 
 # Accept both compressed and already‑unzipped files
 patterns = ["*.htseq.counts.gz", "*.htseq.counts"]
-count_files = []
-for pat in patterns:
-    count_files.extend(ROOT.rglob(pat))
 
-print(f"Found {len(count_files)} files")
-if not count_files:
-    raise SystemExit("Nothing matched – check ROOT path & file names")
-
-def read_one_htseq(path: Path) -> pd.Series:
+def read_counts(path: Path) -> pd.Series:
     """Return a pandas Series of counts indexed by gene_id."""
-    # autodetect gzip vs plain
     comp = "gzip" if path.suffix == ".gz" else "infer"
     df = pd.read_csv(
         path,
@@ -36,28 +31,53 @@ def read_one_htseq(path: Path) -> pd.Series:
     df["gene_id"] = df["gene_id"].str.split(".").str[0]   # strip version suffix
     return df.set_index("gene_id")["count"]
 
-# 1. Read & merge
-counts = pd.concat(
-    [read_one_htseq(fp) for fp in count_files],
-    axis=1,
-    sort=False,
-)
+def merge_counts(files: list[Path]) -> pd.DataFrame:
+    """Read many HTSeq-Count files and merge into a DataFrame."""
+    series = []
+    names = []
+    for fp in files:
+        try:
+            s = read_counts(fp)
+        except Exception as e:
+            logging.error("Failed to parse %s: %s", fp, e)
+            continue
+        series.append(s)
+        names.append(fp.name.split(".")[0])
+    if not series:
+        raise SystemExit("No valid count files were parsed")
+    df = pd.concat(series, axis=1, sort=False)
+    df.columns = names
+    return df
 
-counts.columns = [fp.name.split(".")[0] for fp in count_files]
-print("Matrix shape (genes × samples):", counts.shape)
+def main() -> None:
+    count_files: list[Path] = []
+    for pat in patterns:
+        count_files.extend(ROOT.rglob(pat))
 
-# 2. Filter low genes
-libsize = counts.sum(axis=0)
-cpm = counts.divide(libsize, axis=1) * 1_000_000
-keep = (cpm >= 1).sum(axis=1) >= 0.20 * cpm.shape[1]
-counts = counts[keep]
-print(f"Kept {keep.sum()} genes after CPM filter")
+    print(f"Found {len(count_files)} files")
+    if not count_files:
+        raise SystemExit("Nothing matched – check ROOT path & file names")
 
-# 3. Recompute CPM & log2‑transform
-libsize = counts.sum(axis=0)
-log2_cpm = np.log2(counts.divide(libsize, axis=1) * 1_000_000 + 1)
+    # 1. Read & merge
+    counts = merge_counts(count_files)
+    print("Matrix shape (genes × samples):", counts.shape)
 
-# 4. Save
-out = Path.cwd() / "TCGA_COAD_READ_log2CPM.tsv"
-log2_cpm.to_csv(out, sep="\t")
-print("✔️  Saved", out)
+    # 2. Filter low genes
+    libsize = counts.sum(axis=0)
+    cpm = counts.divide(libsize, axis=1) * 1_000_000
+    keep = (cpm >= 1).sum(axis=1) >= 0.20 * cpm.shape[1]
+    counts = counts[keep]
+    print(f"Kept {keep.sum()} genes after CPM filter")
+
+    # 3. Recompute CPM & log2‑transform
+    libsize = counts.sum(axis=0)
+    log2_cpm = np.log2(counts.divide(libsize, axis=1) * 1_000_000 + 1)
+
+    # 4. Save
+    out = Path.cwd() / "TCGA_COAD_READ_log2CPM.tsv"
+    log2_cpm.to_csv(out, sep="\t")
+    print("✔️  Saved", out)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_merge_counts.py
+++ b/tests/test_merge_counts.py
@@ -1,0 +1,32 @@
+import logging
+import pytest
+from pathlib import Path
+from crcClean import merge_counts
+
+
+def write_htseq(path: Path, content: str) -> Path:
+    path.write_text(content)
+    return path
+
+
+def test_merge_counts_skips_bad_file(tmp_path, caplog):
+    valid = write_htseq(
+        tmp_path / "good.htseq.counts",
+        "geneA\t1\ngeneB\t2\n__no_feature\t0\n",
+    )
+    bad = write_htseq(tmp_path / "bad.htseq.counts", "bad\tvalue\n")
+
+    with caplog.at_level(logging.ERROR):
+        df = merge_counts([valid, bad])
+
+    assert df.shape[1] == 1
+    assert "good" in df.columns
+    assert "Failed to parse" in caplog.text
+
+
+def test_merge_counts_all_bad(tmp_path):
+    bad1 = tmp_path / "bad1.htseq.counts"
+    bad1.write_text("bad\tvalue\n")
+
+    with pytest.raises(SystemExit):
+        merge_counts([bad1])


### PR DESCRIPTION
## Summary
- improve `crcClean.py` to skip files that fail to parse
- add `main()` entry point to avoid running on import
- add tests for malformed input files

## Testing
- `pytest -q` *(fails: No module named 'crcClean' because pandas is missing)*

------
https://chatgpt.com/codex/tasks/task_b_68840d5cad548325bb8de52cca4f97b0